### PR TITLE
Fix `onDrawForeground` patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function nodeDrawProfiler(node) {
   }
   const orig = node.onDrawForeground;
   node.onDrawForeground = function(ctx) {
-    const ret = orig?.apply(ctx, arguments);
+    const ret = orig?.apply(node, arguments);
     drawText(ctx, node.profilingTime || '');
     return ret;
   };


### PR DESCRIPTION
`apply` should maintain the original `node` instance context. Doing `apply(ctx, arguments)` in this case sets `this` to `ctx` rather than `node`. This breaks other extensions which patch `onDrawForeground` and use `this` inside those patches to try to refer to the node instance.